### PR TITLE
`file(encoding = "UTF-8")` in yaml.load_file

### DIFF
--- a/pkg/R/yaml.load_file.R
+++ b/pkg/R/yaml.load_file.R
@@ -12,6 +12,9 @@ function(input, error.label, ...) {
       error.label <- input[1]
     }
   }
-  yaml.load(paste(readLines(file(input, encoding = 'UTF-8')), collapse="\n"),
+  
+  con <- file(input, encoding = 'UTF-8');
+  on.exit(close(con));
+  yaml.load(paste(readLines(con), collapse="\n"),
             error.label = error.label, ...)
 }

--- a/pkg/R/yaml.load_file.R
+++ b/pkg/R/yaml.load_file.R
@@ -12,6 +12,6 @@ function(input, error.label, ...) {
       error.label <- input[1]
     }
   }
-  yaml.load(paste(readLines(input, encoding = 'UTF-8'), collapse="\n"),
+  yaml.load(paste(readLines(file(input, encoding = 'UTF-8'), encoding = 'UTF-8'), collapse="\n"),
             error.label = error.label, ...)
 }

--- a/pkg/R/yaml.load_file.R
+++ b/pkg/R/yaml.load_file.R
@@ -14,8 +14,8 @@ function(input, error.label, ...) {
   }
   
   if(is.character(input)) {
-    con <- file(input, encoding = 'UTF-8');
-    on.exit(close(con));
+    con <- file(input, encoding = 'UTF-8')
+    on.exit(close(con))
   } else {
     con <- input
   }

--- a/pkg/R/yaml.load_file.R
+++ b/pkg/R/yaml.load_file.R
@@ -13,8 +13,12 @@ function(input, error.label, ...) {
     }
   }
   
-  con <- file(input, encoding = 'UTF-8');
-  on.exit(close(con));
+  if(is.character(input)) {
+    con <- file(input, encoding = 'UTF-8');
+    on.exit(close(con));
+  } else {
+    con <- input
+  }
   yaml.load(paste(readLines(con), collapse="\n"),
             error.label = error.label, ...)
 }

--- a/pkg/R/yaml.load_file.R
+++ b/pkg/R/yaml.load_file.R
@@ -12,6 +12,6 @@ function(input, error.label, ...) {
       error.label <- input[1]
     }
   }
-  yaml.load(paste(readLines(file(input, encoding = 'UTF-8'), encoding = 'UTF-8'), collapse="\n"),
+  yaml.load(paste(readLines(file(input, encoding = 'UTF-8')), collapse="\n"),
             error.label = error.label, ...)
 }


### PR DESCRIPTION
replace `readLines(input, encoding = 'UTF-8')` with `readLines(file(input, encoding = "UTF-8"))`, see Issue#38 for details. 