### PR TITLE
Mark the encoding of as.yaml() output as UTF-8

### DIFF
--- a/pkg/R/as.yaml.R
+++ b/pkg/R/as.yaml.R
@@ -1,5 +1,7 @@
 `as.yaml` <-
 function(x, line.sep = c('\n', '\r\n', '\r'), indent = 2, omap = FALSE, column.major = TRUE, unicode = TRUE, precision = getOption('digits'), indent.mapping.sequence = FALSE) {
   line.sep <- match.arg(line.sep)
-  .Call("serialize_to_yaml", x, line.sep, indent, omap, column.major, unicode, precision, indent.mapping.sequence, PACKAGE="yaml")
+  res <- .Call("serialize_to_yaml", x, line.sep, indent, omap, column.major, unicode, precision, indent.mapping.sequence, PACKAGE="yaml")
+  Encoding(res) <- "UTF-8"
+  res
 }


### PR DESCRIPTION
I discovered this bug via https://github.com/rstudio/blogdown/issues/185.