### PR TITLE
Let yaml.load() accept a character vector of length > 1

### DIFF
--- a/pkg/R/yaml.load.R
+++ b/pkg/R/yaml.load.R
@@ -1,4 +1,5 @@
 `yaml.load` <-
 function(string, as.named.list = TRUE, handlers = NULL, error.label = NULL) {
-  .Call("unserialize_from_yaml", enc2utf8(string), as.named.list, handlers, error.label, PACKAGE="yaml")
+  string <- enc2utf8(paste(string, collapse = "\n"))
+  .Call("unserialize_from_yaml", string, as.named.list, handlers, error.label, PACKAGE="yaml")
 }

--- a/pkg/R/yaml.load_file.R
+++ b/pkg/R/yaml.load_file.R
@@ -19,6 +19,6 @@ function(input, error.label, ...) {
   } else {
     con <- input
   }
-  yaml.load(paste(readLines(con), collapse="\n"),
+  yaml.load(readLines(con),
             error.label = error.label, ...)
 }


### PR DESCRIPTION
Otherwise users always have to do `paste(collapse = "\n")` by themselves.