### PR TITLE
on.exit(add = TRUE) is almost always the right thing to do

### DIFF
--- a/pkg/R/yaml.load_file.R
+++ b/pkg/R/yaml.load_file.R
@@ -13,9 +13,9 @@ function(input, error.label, ...) {
     }
   }
   
-  if(is.character(input)) {
+  if (is.character(input)) {
     con <- file(input, encoding = 'UTF-8')
-    on.exit(close(con))
+    on.exit(close(con), add = TRUE)
   } else {
     con <- input
   }


### PR DESCRIPTION
Without add = TRUE, it is easy to shoot yourself in the foot when you have other `on.exit()` calls.