### PR TITLE
Solve 'argument "error.label" is missing, with no default' error.

### DIFF
--- a/R/yaml.load_file.R
+++ b/R/yaml.load_file.R
@@ -11,6 +11,8 @@ function(input, error.label, ...) {
     else if (is.character(input) && nzchar(input[1])) {
       error.label <- input[1]
     }
+   else
+     error.label <- NULL
   }
   
   if (is.character(input)) {


### PR DESCRIPTION
With the latest release of the `yaml` package (2.1.18), lots of folks ([1](https://github.com/rstudio/dygraphs/issues/200), [2](https://github.com/JohnCoene/echarts/issues/7), [3](https://stackoverflow.com/questions/49383689/error-in-yaml-load-argument-error-label-is-missing-with-no-default), ... ) are getting this error message when using packages that depend on `yaml`:

```
Error in yaml.load(readLines(con), error.label = error.label, ...) : 
  argument "error.label" is missing, with no default
```

The key problem is that the code in `yaml.load_file` that attempts to guess a value for `error.label` doesn't provide a value if neither of the guesses apply.  Adding a default `else` case that sets `error.label` resolves the issue.

 