### PR TITLE
Fix small bug in as.yaml docs

### DIFF
--- a/man/as.yaml.Rd
+++ b/man/as.yaml.Rd
@@ -79,7 +79,7 @@
 
   # custom handler
   as.yaml(Sys.time(), handlers = list(
-    POSIXct = function(x) format(Sys.time(), "\%Y-\%m-\%d")
+    POSIXct = function(x) format(x, "\%Y-\%m-\%d")
   ))
 
   # custom handler with verbatim output to change how logical vectors are


### PR DESCRIPTION
This handler would have given the incorrect results:

``` r
library("yaml")
# The future is now?
as.yaml(as.POSIXct("2038-01-20"), handlers = list(
  POSIXct = function(x) format(Sys.time(), "%Y-%m-%d")
))
#> [1] "'2020-08-13'\n"
# Fixed
as.yaml(as.POSIXct("2038-01-20"), handlers = list(
  POSIXct = function(x) format(x, "%Y-%m-%d")
))
#> [1] "'2038-01-20'\n"
```

<sup>Created on 2020-08-13 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>